### PR TITLE
add s390(x) versions of assembler samples

### DIFF
--- a/assembler/01_gas_template/as_ibm_s390
+++ b/assembler/01_gas_template/as_ibm_s390
@@ -1,0 +1,3 @@
+as -m31 s390.s -o s390.o
+ld -melf_s390 -s s390.o
+

--- a/assembler/01_gas_template/as_ibm_s390x
+++ b/assembler/01_gas_template/as_ibm_s390x
@@ -1,0 +1,3 @@
+as s390.s -o s390x.o
+ld -s s390x.o
+

--- a/assembler/01_gas_template/s390.s
+++ b/assembler/01_gas_template/s390.s
@@ -1,0 +1,38 @@
+# asmsyntax=as
+
+# Sablona pro zdrojovy kod Linuxoveho programu naprogramovaneho
+# v assembleru GNU AS.
+#
+# Autor: Pavel Tisnovsky
+#        Dan Horak
+
+
+
+# Linux kernel system call table
+sys_exit=1
+
+
+
+#-----------------------------------------------------------------------------
+.section .data
+
+
+
+#-----------------------------------------------------------------------------
+.section .bss
+
+
+
+#-----------------------------------------------------------------------------
+.section .text
+        .global _start          # tento symbol ma byt dostupny i linkeru
+
+_start:
+        la    1,sys_exit        # cislo sycallu pro funkci "exit"
+        la    2,0               # exit code = 0
+        svc   0                 # volani Linuxoveho kernelu
+
+	# pro syscally < 256 funguje i nasledujici
+#	la	2,0
+#	svc	sys_exit
+

--- a/assembler/03_gas_hello_world/as_ibm_s390
+++ b/assembler/03_gas_hello_world/as_ibm_s390
@@ -1,0 +1,3 @@
+as -m31 hello_world-s390.s -o hello_world-s390.o
+ld -melf_s390 -s hello_world-s390.o
+

--- a/assembler/03_gas_hello_world/as_ibm_s390x
+++ b/assembler/03_gas_hello_world/as_ibm_s390x
@@ -1,0 +1,3 @@
+as hello_world-s390x.s -o hello_world-s390x.o
+ld -s hello_world-s390x.o
+

--- a/assembler/03_gas_hello_world/hello_world-s390.s
+++ b/assembler/03_gas_hello_world/hello_world-s390.s
@@ -1,0 +1,47 @@
+# asmsyntax=as
+
+# Jednoducha aplikace typu "Hello world!" naprogramovana
+# v assembleru GNU as.
+#
+# Autor: Pavel Tisnovsky
+#        Dan Horak
+
+
+
+# Linux kernel system call table
+sys_exit=1
+sys_write=4
+
+
+
+#-----------------------------------------------------------------------------
+.section .data
+
+hello_lbl:
+        .string "Hello World!\n"
+
+#-----------------------------------------------------------------------------
+.section .bss
+
+
+
+#-----------------------------------------------------------------------------
+.section .text
+        .global _start          # tento symbol ma byt dostupny i linkeru
+
+_start:
+	basr  13,0		# nastaveni literal poolu
+.L0:	ahi   13,.LT0-.L0
+        la    1,sys_write       # cislo syscallu pro funkci "write"
+        la    2,1               # standardni vystup
+        l     3,.LC1-.LT0(13)   # adresa retezce, ktery se ma vytisknout
+        la    4,13              # pocet znaku, ktere se maji vytisknout
+        svc   0                 # volani Linuxoveho kernelu
+
+        la    1,sys_exit        # cislo sycallu pro funkci "exit"
+        la    2,0               # exit code = 0
+        svc   0                 # volani Linuxoveho kernelu
+
+# literal pool
+.LT0:
+.LC1:	.long	hello_lbl

--- a/assembler/03_gas_hello_world/hello_world-s390x.s
+++ b/assembler/03_gas_hello_world/hello_world-s390x.s
@@ -1,0 +1,42 @@
+# asmsyntax=as
+
+# Jednoducha aplikace typu "Hello world!" naprogramovana
+# v assembleru GNU as.
+#
+# Autor: Pavel Tisnovsky
+#        Dan Horak
+
+
+
+# Linux kernel system call table
+sys_exit=1
+sys_write=4
+
+
+
+#-----------------------------------------------------------------------------
+.section .data
+
+hello_lbl:
+        .string "Hello World!\n"
+
+#-----------------------------------------------------------------------------
+.section .bss
+
+
+
+#-----------------------------------------------------------------------------
+.section .text
+        .global _start          # tento symbol ma byt dostupny i linkeru
+
+_start:
+        la    1,sys_write       # cislo syscallu pro funkci "write"
+        la    2,1               # standardni vystup
+        larl  3,hello_lbl       # adresa retezce, ktery se ma vytisknout
+        la    4,13              # pocet znaku, ktere se maji vytisknout
+        svc   0                 # volani Linuxoveho kernelu
+
+        la    1,sys_exit        # cislo sycallu pro funkci "exit"
+        la    2,0               # exit code = 0
+        svc   0                 # volani Linuxoveho kernelu
+


### PR DESCRIPTION
The s390(x) versions of assembler samples expect native toolchain, so need
either a Linux guest running on real iron or Linux running under Hercules
emulator.